### PR TITLE
Handle flexible time formats when parsing log datasets

### DIFF
--- a/src/main/java/org/chart/service/LogParserService.java
+++ b/src/main/java/org/chart/service/LogParserService.java
@@ -15,9 +15,14 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
 import java.util.*;
 
 /**
@@ -27,6 +32,16 @@ public class LogParserService {
 
     private static final String DATASET_MARKER = "RawService.UpdateStorageRaw.DataSet:";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy H:mm[:ss]");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+    private static final DateTimeFormatter TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalEnd()
+            .toFormatter();
 
     public DataModel parse(Path file) throws IOException {
         Objects.requireNonNull(file, "file");
@@ -85,7 +100,7 @@ public class LogParserService {
             if (tankId.isBlank()) {
                 tankId = "Tank 1";
             }
-            LocalDateTime timestamp = parseTimestamp(safeValue(row.values(), 1, null));
+            LocalDateTime timestamp = parseTimestamp(row);
             double levelRaw = parseNumber(row.values()[4]);
 
             DataPoint point = new DataPoint(
@@ -195,14 +210,180 @@ public class LogParserService {
         return bestIndex >= 0 ? bestIndex : 0;
     }
 
-    private static LocalDateTime parseTimestamp(String value) {
-        if (value == null || value.isBlank()) {
+    private static LocalDateTime parseTimestamp(ParsedRow row) {
+        String[] values = row.values();
+        String timeValue = extract(values, 1);
+        if (timeValue == null || timeValue.isBlank()) {
             throw new IllegalArgumentException("Пустое значение времени");
         }
+
+        LocalDateTime direct = tryParseDateTime(timeValue);
+        if (direct != null) {
+            return direct;
+        }
+
+        String dateValue = extract(values, 0);
+        LocalDate datePart = tryParseDate(dateValue);
+        if (datePart != null) {
+            LocalTime timePart = tryParseTime(timeValue);
+            if (timePart != null) {
+                return LocalDateTime.of(datePart, timePart);
+            }
+        }
+
+        throw new IllegalArgumentException("Не удалось распарсить дату/время: " + timeValue);
+    }
+
+    private static String extract(String[] values, int index) {
+        if (index >= 0 && index < values.length) {
+            String value = values[index];
+            return value == null ? null : value.trim();
+        }
+        return null;
+    }
+
+    private static LocalDateTime tryParseDateTime(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        List<String> candidates = new ArrayList<>();
+        String trimmed = value.trim();
+        candidates.add(trimmed);
+        String normalized = normalizeDateTime(trimmed);
+        if (!normalized.equals(trimmed)) {
+            candidates.add(normalized);
+        }
+
+        for (String candidate : candidates) {
+            try {
+                return LocalDateTime.parse(candidate, DATE_TIME_FORMATTER);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        return null;
+    }
+
+    private static LocalDate tryParseDate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        String normalized = trimmed.replace('/', '.');
         try {
-            return LocalDateTime.parse(value, DATE_TIME_FORMATTER);
-        } catch (DateTimeParseException ex) {
-            throw new IllegalArgumentException("Не удалось распарсить дату/время: " + value, ex);
+            return LocalDate.parse(normalized, DATE_FORMATTER);
+        } catch (DateTimeParseException ignored) {
+            return null;
+        }
+    }
+
+    private static LocalTime tryParseTime(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        List<String> candidates = new ArrayList<>();
+        String trimmed = value.trim();
+        candidates.add(trimmed);
+        String normalized = normalizeTime(trimmed);
+        if (!normalized.equals(trimmed)) {
+            candidates.add(normalized);
+        }
+
+        for (String candidate : candidates) {
+            try {
+                return LocalTime.parse(candidate, TIME_FORMATTER);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        for (String candidate : candidates) {
+            LocalTime fromDecimal = parseDecimalTime(candidate);
+            if (fromDecimal != null) {
+                return fromDecimal;
+            }
+        }
+
+        return null;
+    }
+
+    private static String normalizeDateTime(String value) {
+        int spaceIndex = value.indexOf(' ');
+        if (spaceIndex < 0) {
+            return normalizeTime(value);
+        }
+        String datePart = value.substring(0, spaceIndex).replace('/', '.');
+        String timePart = normalizeTime(value.substring(spaceIndex + 1));
+        return datePart + " " + timePart;
+    }
+
+    private static String normalizeTime(String value) {
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return trimmed;
+        }
+
+        String candidate = trimmed.replace('.', ':');
+        if (candidate.contains(",") && !candidate.contains(":")) {
+            String[] parts = candidate.split(",", -1);
+            if (parts.length == 2 && parts[0].matches("\\d{1,2}") && parts[1].matches("\\d{1,2}")) {
+                String minutes = parts[1].length() == 1 ? "0" + parts[1] : parts[1];
+                candidate = parts[0] + ":" + minutes;
+            } else {
+                candidate = candidate.replace(',', ':');
+            }
+        } else {
+            candidate = candidate.replace(',', ':');
+        }
+
+        long colonCount = candidate.chars().filter(ch -> ch == ':').count();
+        if (colonCount == 1) {
+            int colonIndex = candidate.indexOf(':');
+            if (colonIndex >= 0 && colonIndex < candidate.length() - 1) {
+                String minutes = candidate.substring(colonIndex + 1);
+                if (minutes.length() == 1) {
+                    candidate = candidate.substring(0, colonIndex + 1) + "0" + minutes;
+                }
+            }
+        }
+
+        return candidate;
+    }
+
+    private static LocalTime parseDecimalTime(String value) {
+        if (value.contains(":")) {
+            return null;
+        }
+        String normalized = value.replace(',', '.');
+        try {
+            double hours = Double.parseDouble(normalized);
+            if (!Double.isFinite(hours)) {
+                return null;
+            }
+            int wholeHours = (int) Math.floor(hours);
+            double fractional = hours - wholeHours;
+            int totalSeconds = (int) Math.round(fractional * 3600);
+            while (totalSeconds >= 3600) {
+                wholeHours++;
+                totalSeconds -= 3600;
+            }
+            if (wholeHours >= 24) {
+                return null;
+            }
+            int minutes = totalSeconds / 60;
+            int seconds = totalSeconds % 60;
+            if (minutes >= 60) {
+                minutes -= 60;
+                wholeHours++;
+                if (wholeHours >= 24) {
+                    return null;
+                }
+            }
+            return LocalTime.of(wholeHours, minutes, seconds);
+        } catch (NumberFormatException ex) {
+            return null;
         }
     }
 


### PR DESCRIPTION
## Summary
- expand log timestamp parsing to support additional date and time layouts
- normalize comma-separated time values and fallback to combining separate date/time columns
- add decimal-time interpretation to avoid failures when loading datasets

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dfd7b0c0848323819fc3dbe7dc5fe3