### PR TITLE
Add parser for RawService UpdateStorageRaw dataset blocks

### DIFF
--- a/src/main/java/org/chart/parser/LogParser.java
+++ b/src/main/java/org/chart/parser/LogParser.java
@@ -1,0 +1,124 @@
+package org.chart.parser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Parser that extracts only storage raw dataset entries from the log files.
+ *
+ * <p>The parser looks for log blocks that start with a line similar to
+ * "[01.05.25 00:30:39,746] RawService.UpdateStorageRaw.DataSet:" followed by one or more
+ * lines that contain semicolon separated values written to the database. Each of those
+ * database lines represents a single tank.</p>
+ */
+public final class LogParser {
+
+    private static final Pattern DATASET_HEADER = Pattern.compile(
+            "\\[.*?]\\s+RawService\\.UpdateStorageRaw\\.DataSet:.*");
+
+    private static final Pattern DATA_LINE = Pattern.compile("\\d+;.*");
+
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("dd.MM.yyyy H:mm:ss", Locale.ROOT);
+
+    /**
+     * Parses the provided log file.
+     *
+     * @param path path to the log file
+     * @return list of tank records extracted from the log
+     * @throws IOException if reading the file fails
+     */
+    public List<TankRecord> parse(Path path) throws IOException {
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            return parse(reader);
+        }
+    }
+
+    /**
+     * Parses log data from the provided reader.
+     *
+     * @param reader reader with log data
+     * @return list of tank records extracted from the log
+     * @throws IOException if reading from the reader fails
+     */
+    public List<TankRecord> parse(Reader reader) throws IOException {
+        Objects.requireNonNull(reader, "reader");
+
+        List<TankRecord> result = new ArrayList<>();
+        try (BufferedReader bufferedReader = reader instanceof BufferedReader br ? br : new BufferedReader(reader)) {
+            String line;
+            boolean inDatasetBlock = false;
+
+            while ((line = bufferedReader.readLine()) != null) {
+                if (isDatasetHeader(line)) {
+                    inDatasetBlock = true;
+                    continue;
+                }
+
+                String trimmedLine = line.trim();
+
+                if (trimmedLine.isEmpty()) {
+                    inDatasetBlock = false;
+                    continue;
+                }
+
+                if (trimmedLine.startsWith("[")) {
+                    inDatasetBlock = false;
+                }
+
+                if (!inDatasetBlock) {
+                    continue;
+                }
+
+                TankRecord record = parseDataLine(trimmedLine);
+                if (record != null) {
+                    result.add(record);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static boolean isDatasetHeader(String line) {
+        return DATASET_HEADER.matcher(line.trim()).matches();
+    }
+
+    private static TankRecord parseDataLine(String line) {
+        if (line.isEmpty() || !DATA_LINE.matcher(line).matches()) {
+            return null;
+        }
+
+        String[] tokens = line.split(";");
+        if (tokens.length < 5) {
+            return null;
+        }
+
+        try {
+            long tankId = Long.parseLong(tokens[0].trim());
+            LocalDateTime timestamp = LocalDateTime.parse(tokens[1].trim(), TIMESTAMP_FORMATTER);
+            BigDecimal levelRaw = parseBigDecimal(tokens[4]);
+
+            return new TankRecord(tankId, timestamp, levelRaw);
+        } catch (NumberFormatException | DateTimeParseException ex) {
+            return null;
+        }
+    }
+
+    private static BigDecimal parseBigDecimal(String value) {
+        String normalized = value.trim().replace(',', '.');
+        return new BigDecimal(normalized);
+    }
+}

--- a/src/main/java/org/chart/parser/TankRecord.java
+++ b/src/main/java/org/chart/parser/TankRecord.java
@@ -1,0 +1,10 @@
+package org.chart.parser;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Represents a single tank entry extracted from the log.
+ */
+public record TankRecord(long tankId, LocalDateTime timestamp, BigDecimal levelRaw) {
+}

--- a/src/test/java/org/chart/parser/LogParserTest.java
+++ b/src/test/java/org/chart/parser/LogParserTest.java
@@ -1,0 +1,64 @@
+package org.chart.parser;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+class LogParserTest {
+
+    @Test
+    void parsesOnlyDatasetEntries() throws IOException {
+        String log = """
+                [01.05.25 00:30:10,111] Some.Other.Service: ignored line
+                [01.05.25 00:30:39,746] RawService.UpdateStorageRaw.DataSet:
+                877000000002265;01.05.2025 0:30:39;8507,6580;0,8315;14,5;132,2;0;ru_2025.02.25.32047;524288;
+                877000000002266;01.05.2025 0:30:22;11760,0620;0,735;15;136,7;0;ru_2025.02.25.32047;524288;
+                [01.05.25 00:31:00,000] RawService.UpdateStorageRaw.DataSet:
+                877000000002267;01.05.2025 0:31:00;5019,6560;0,7346;15;88,4;0;ru_2025.02.25.32047;524288;
+                [01.05.25 00:32:00,000] Another.Service: should be ignored
+                """;
+
+        LogParser parser = new LogParser();
+        List<TankRecord> records = parser.parse(new StringReader(log));
+
+        assertEquals(3, records.size());
+
+        assertEquals(new TankRecord(877000000002265L,
+                        LocalDateTime.of(2025, 5, 1, 0, 30, 39),
+                        new BigDecimal("14.5")),
+                records.get(0));
+        assertEquals(new TankRecord(877000000002266L,
+                        LocalDateTime.of(2025, 5, 1, 0, 30, 22),
+                        new BigDecimal("15")),
+                records.get(1));
+        assertEquals(new TankRecord(877000000002267L,
+                        LocalDateTime.of(2025, 5, 1, 0, 31),
+                        new BigDecimal("15")),
+                records.get(2));
+    }
+
+    @Test
+    void ignoresMalformedDataLines() throws IOException {
+        String log = """
+                [01.05.25 00:30:39,746] RawService.UpdateStorageRaw.DataSet:
+                not-a-valid-line
+                877000000002265;bad-date;8507,6580;0,8315;14,5;132,2;0;ru_2025.02.25.32047;524288;
+                877000000002266;01.05.2025 0:30:22;11760,0620;0,735;15;136,7;0;ru_2025.02.25.32047;524288;
+                """;
+
+        LogParser parser = new LogParser();
+        List<TankRecord> records = parser.parse(new StringReader(log));
+
+        assertIterableEquals(List.of(new TankRecord(877000000002266L,
+                        LocalDateTime.of(2025, 5, 1, 0, 30, 22),
+                        new BigDecimal("15"))),
+                records);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a dedicated log parser that extracts tank records only from RawService.UpdateStorageRaw.DataSet sections
- add a TankRecord data structure to capture tank id, timestamp, and level raw values
- cover the parser with tests to verify dataset filtering and resilience to malformed lines

## Testing
- mvn -q -DskipTests=false test *(fails: invalid target release 24 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdf691e948323aa1bd0d86641a15c