### PR TITLE
Fix levelRaw parsing index

### DIFF
--- a/src/main/java/org/chart/service/LogParserService.java
+++ b/src/main/java/org/chart/service/LogParserService.java
@@ -82,13 +82,13 @@ public class LogParserService {
 
         for (int i = 0; i < rows.size(); i++) {
             ParsedRow row = rows.get(i);
-            if (row.values().length < 5) {
+            if (row.values().length < 4) {
                 continue;
             }
 
             String tankId = safeValue(row.values(), 0, "Tank " + (i + 1));
             LocalDateTime timestamp = parseTimestamp(requiredValue(row.values(), 1));
-            double levelRaw = parseNumber(row.values()[4]);
+            double levelRaw = parseNumber(row.values()[3]);
 
             DataPoint point = new DataPoint(
                     tankId,


### PR DESCRIPTION
## Summary
- parse the `levelRaw` value from the fourth column of each dataset row
- align the row length guard with the updated column index

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dfe95ad21883238c222108f2c6a17c